### PR TITLE
Add type checking for base class inputs

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -24,8 +24,15 @@ function peggyArray(a, joiner, needed, parent) {
   return a.toPeggy(needed, parent);
 }
 
-class Base {
+// Only exported for testing
+export class Base {
   constructor(type, loc, simple = true) {
+    if (typeof type !== "string") {
+      throw new TypeError(`Invalid type: ${type}`);
+    }
+    if (!loc || (typeof loc !== "object")) {
+      throw new TypeError(`Invalid location: ${loc} for ${type}`);
+    }
     this.type = type;
     this.loc = loc;
     this.simple = simple;
@@ -246,7 +253,7 @@ export class Group extends Base {
 
 export class Rules extends Base {
   constructor() {
-    super("rules");
+    super("rules", {}); // Location will be replaced later
     this.defs = {};
     this.refs = [];
     this.first = null;

--- a/test/ast.ava.js
+++ b/test/ast.ava.js
@@ -6,3 +6,8 @@ test("range escape", t => {
   t.is(ast.Range.escape(0x7c), "\\x7c");
   t.is(ast.Range.escape(0x100), "\\u0100");
 });
+
+test("bad base class types", t => {
+  t.throws(() => new ast.Base());
+  t.throws(() => new ast.Range("", 0, 1));
+});


### PR DESCRIPTION
To prevent location elision in the future.  Related to #9.