### PR TITLE
Add extension to main script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "abnf_gen": "bin/abnf_gen.js",
     "abnf_test": "bin/abnf_test.js"
   },
-  "main": "lib/abnf",
+  "main": "lib/abnf.js",
   "type": "module",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Otherwise, node complains “automatic extension resolution of the main field is deprecated for ES modules”