### PR TITLE
chore: refactor abnf_check's check_refs() into abnf.checkRefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ the name of the file that the input came from.
 Read the stream, parse it, and return a promise for a Rules object.  The
 `grammarSource` is the name of the file that the input came from.
 
+### .checkRefs(rules)
+
+This is used by the `abnf_check` utility, and returns null if there are no reference errors, otherwise returns an array of error strings. Checks for unused or undefined rules.
+
 ## Returned Rules object shape
 
 ### Rules.first

--- a/bin/abnf_check.js
+++ b/bin/abnf_check.js
@@ -2,28 +2,6 @@
 import * as abnf from "../lib/abnf.js";
 import { Command } from "commander";
 
-function check_refs(rules) {
-  let ret = 0;
-  rules.refs.forEach(ref => {
-    if (!Object.prototype.hasOwnProperty.call(
-      rules.defs,
-      ref.name.toUpperCase()
-    )) {
-      const loc = ref.loc;
-      console.log(`Reference to unknown rule "${ref.name}" at ${loc.source}:${loc.start.line}`);
-      ret = 3;
-    }
-  });
-  for (const name in rules.defs) {
-    if ((rules.findRefs(name).length === 0) && (name !== rules.first)) {
-      const loc = rules.defs[name].loc;
-      console.log(`Unreferenced rule "${name}" at ${loc.source}:${loc.start.line}`);
-      ret = 3;
-    }
-  }
-  return ret;
-}
-
 let exitCode = 0;
 const program = new Command();
 program
@@ -55,9 +33,12 @@ program
         }
         throw er;
       }
-      const cr = check_refs(rules, opts);
-      if (cr) {
-        exitCode = cr;
+      const errs = abnf.checkRefs(rules, opts);
+      if (errs) {
+        for (const err of errs) {
+          console.error(err);
+        }
+        exitCode = 3;
       }
     }
   })

--- a/lib/abnf.js
+++ b/lib/abnf.js
@@ -53,3 +53,28 @@ export function parseStream(input, grammarSource = "stdin", utf16 = true) {
 export function parseFile(input, utf16 = true) {
   return parseString(fs.readFileSync(input, "utf8"), input, utf16);
 }
+
+/** @returns null if no errors, else an array of errors */
+export function checkRefs(rules) {
+  const errs = [];
+  rules.refs.forEach(ref => {
+    if (!Object.prototype.hasOwnProperty.call(
+      rules.defs,
+      ref.name.toUpperCase()
+    )) {
+      const loc = ref.loc;
+      errs.push(`Reference to unknown rule "${ref.name}" at ${loc.source}:${loc.start.line}`);
+    }
+  });
+  for (const name in rules.defs) {
+    if ((rules.findRefs(name).length === 0) && (name !== rules.first)) {
+      const loc = rules.defs[name].loc;
+      errs.push(`Unreferenced rule "${name}" at ${loc.source}:${loc.start.line}`);
+    }
+  }
+  if (!errs.length) {
+    return null;
+  } else {
+    return errs;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     {
       "name": "ZP-ZPanda",
       "email": "zp.zpanda@gmail.com"
+    },
+    {
+      "name": "Steven R. Loomis",
+      "email": "srl295@codehivetx.us"
     }
   ],
   "homepage": "https://github.com/hildjj/node-abnf",
@@ -66,5 +70,6 @@
   "packageManager": "pnpm@9.15.2",
   "engines": {
     "node": ">=18"
-  }
+  },
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
- this is a useful function, so splitting it out and exporting